### PR TITLE
Add missing deps to test suite

### DIFF
--- a/rose-trees.cabal
+++ b/rose-trees.cabal
@@ -77,10 +77,12 @@ Benchmark bench
                       , deepseq
                       , rose-trees
                       , containers
+                      , hashable
                       , mtl
                       , semigroups
                       , semigroupoids
                       , sets
+                      , unordered-containers
                       , witherable
                       , QuickCheck
                       , quickcheck-instances

--- a/rose-trees.cabal
+++ b/rose-trees.cabal
@@ -48,11 +48,13 @@ Test-Suite spec
                       , deepseq
                       , rose-trees
                       , containers
+                      , hashable
                       , semigroups
                       , semigroupoids
                       , sets
                       , tasty
                       , tasty-quickcheck
+                      , unordered-containers
                       , witherable
                       , QuickCheck
                       , quickcheck-instances


### PR DESCRIPTION
Running the test suite from the tarball resulted in the following error:

```
Preprocessing test suite 'spec' for rose-trees-0.0.4.1...
[1 of 7] Compiling Data.Tree.Hash   ( src/Data/Tree/Hash.hs, dist/build/spec/spec-tmp/Data/Tree/Hash.o )

src/Data/Tree/Hash.hs:12:1: error:
    Failed to load interface for ‘Data.HashSet’
    It is a member of the hidden package ‘unordered-containers-0.2.7.1’.
    Perhaps you need to add ‘unordered-containers’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.

src/Data/Tree/Hash.hs:16:1: error:
    Failed to load interface for ‘Data.Hashable’
    It is a member of the hidden package ‘hashable-1.2.4.0’.
    Perhaps you need to add ‘hashable’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
```

Seen on the stackage build server. I was also able to reproduce it on my local machine as follows:

```
stack unpack rose-trees-0.0.4.1
cd rose-trees-0.0.4.1/
stack init --resolver nightly-2016-06-08
stack test
```

Issue is fixed via the proposed changes to the cabal file.
